### PR TITLE
Using bazel query language and quick pick details

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
                     "default": [],
                     "description": "Packages that should not be considered during querying, e.g. tools/compiler"
                 },
-                "bazel.enableTableView": {
+                "bazel.rawLabelDisplay": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Show the label list as a table"
+                    "description": "When set to true labels will not be parsed"
                 }
             }
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -112,7 +112,7 @@ export async function bzlBuildTarget(ctx: ExtensionContext) {
 }
 
 export async function bzlRunTarget(ctx: ExtensionContext) {
-    var target = await bzlQuickPickQuery('kind(.*_binary, deps(//:*))', {
+    var target = await bzlQuickPickQuery('kind(.*_binary, deps(...))', {
         matchOnDescription: true,
         matchOnDetail: true,
         placeHolder: "Run bazel binary target (*_binary)"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -61,7 +61,7 @@ async function bzlQuery(query: string = '...'): Promise<BazelQueryItem[]> {
     let bzl_config = Workspace.getConfiguration('bazel')
     let excluded_packages = bzl_config.packageExcludes.join(',')
     let child = await bzl_utils.bzlRunCommandFromShell('query '
-        + `${query}`
+        + query
         + ' --noimplicit_deps'
         + ' --nohost_deps'
         + ' --deleted_packages=' + excluded_packages
@@ -112,7 +112,7 @@ export async function bzlBuildTarget(ctx: ExtensionContext) {
 }
 
 export async function bzlRunTarget(ctx: ExtensionContext) {
-    var target = await bzlQuickPickQuery('kind(".*_binary", deps("..."))', {
+    var target = await bzlQuickPickQuery('kind(.*_binary, deps(...))', {
         matchOnDescription: true,
         matchOnDetail: true,
         placeHolder: "Run bazel binary target (*_binary)"
@@ -261,7 +261,7 @@ export async function bzlCreateCppProps(ctx: ExtensionContext) {
                 ]
                 // For c_cpp_properties we are only
                 // interested in C++ targets.
-                var target = await bzlQuickPickQuery('kind("cc_.*", deps("..."))', {
+                var target = await bzlQuickPickQuery('kind(cc_.*, deps(...))', {
                     matchOnDescription: true,
                     matchOnDetail: true,
                     placeHolder: "Generate cpp properties for target ..."

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -61,7 +61,7 @@ async function bzlQuery(query: string = '...'): Promise<BazelQueryItem[]> {
     let bzl_config = Workspace.getConfiguration('bazel')
     let excluded_packages = bzl_config.packageExcludes.join(',')
     let child = await bzl_utils.bzlRunCommandFromShell('query '
-        + query
+        + `"${query}"`
         + ' --noimplicit_deps'
         + ' --nohost_deps'
         + ' --deleted_packages=' + excluded_packages

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -61,7 +61,7 @@ async function bzlQuery(query: string = '...'): Promise<BazelQueryItem[]> {
     let bzl_config = Workspace.getConfiguration('bazel')
     let excluded_packages = bzl_config.packageExcludes.join(',')
     let child = await bzl_utils.bzlRunCommandFromShell('query '
-        + query
+        + `${query}`
         + ' --noimplicit_deps'
         + ' --nohost_deps'
         + ' --deleted_packages=' + excluded_packages
@@ -112,7 +112,7 @@ export async function bzlBuildTarget(ctx: ExtensionContext) {
 }
 
 export async function bzlRunTarget(ctx: ExtensionContext) {
-    var target = await bzlQuickPickQuery('kind(.*_binary, deps(...))', {
+    var target = await bzlQuickPickQuery('kind(".*_binary", deps("..."))', {
         matchOnDescription: true,
         matchOnDetail: true,
         placeHolder: "Run bazel binary target (*_binary)"
@@ -261,7 +261,7 @@ export async function bzlCreateCppProps(ctx: ExtensionContext) {
                 ]
                 // For c_cpp_properties we are only
                 // interested in C++ targets.
-                var target = await bzlQuickPickQuery('kind(cc_.*, deps(...))', {
+                var target = await bzlQuickPickQuery('kind("cc_.*", deps("..."))', {
                     matchOnDescription: true,
                     matchOnDetail: true,
                     placeHolder: "Generate cpp properties for target ..."


### PR DESCRIPTION
A couple improvments to the look and the responsiveness of the target
quick pick.
* Quick pick no longer waits until the bazel query finishes
* Using bazel query language instead of filtering in javascript
* Only showing binary targets for bazel run
* Making use of the QuickPickItem details property to show more
information in the quick pick
* Removed the table view option because it doesn't make sense when used
with QuickPickItem details property and there was a display bug on my
machine anyways. See issue #1 

Demo of quick pick display changes:
![rawlabeldisplay](https://user-images.githubusercontent.com/1284289/37637529-8bac89a4-2bc5-11e8-966e-e4460575b0ec.gif)

Based on this branch I made some crude diagnostics: https://github.com/zaucy/vscode-bazel-tools/pull/1

![diagnostics](https://user-images.githubusercontent.com/1284289/37642590-f5d87cba-2bda-11e8-9f61-5ba82fa17f4f.gif)